### PR TITLE
update uglify version in dev deps to fix npm install error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "tap": "~0.4.8",
-    "uglifyjs": "~2.3.6",
+    "uglifyjs": "~2.4.10",
     "browserify": "~5.9.3"
   }
 }


### PR DESCRIPTION
```
npm install
npm ERR! notarget No compatible version found: uglifyjs@'>=2.3.6-0 <2.4.0-0'
```