### PR TITLE
Add space-separated output formatting option

### DIFF
--- a/bin/geojson-extent
+++ b/bin/geojson-extent
@@ -3,7 +3,7 @@
 var geojsonExtent = require('../'),
     rw = require('rw');
 
-var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin/')));
+var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin')));
 
 if (process.argv[2] == 'leaflet') {
     console.log(JSON.stringify([

--- a/bin/geojson-extent
+++ b/bin/geojson-extent
@@ -3,13 +3,19 @@
 var geojsonExtent = require('../'),
     rw = require('rw');
 
-var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin')));
-
-if (process.argv[2] == 'leaflet') {
-    console.log(JSON.stringify([
-        [ext[1], ext[0]],
-        [ext[3], ext[2]]
-    ]));
-} else {
-    console.log(JSON.stringify(ext));
+function format_extent(ext, format) {
+    switch(format) {
+        case 'leaflet':
+            return JSON.stringify([
+                [ext[1], ext[0]],
+                [ext[3], ext[2]]
+            ]);
+        case 'spaces':
+            return ext.join(' ');
+        default:
+            return JSON.stringify(ext);
+    }
 }
+
+var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin')));
+console.log(format_extent(ext, process.argv[2]))


### PR DESCRIPTION
There are [many](https://github.com/d3/d3-geo/blob/master/README.md#geoBounds) [ways](https://github.com/d3/d3-geo/blob/master/README.md#path_bounds) to specify a bounding box, but I happen to be wanting to use this with [tl](https://github.com/mojodna/tl/blob/master/lib/commands/copy.js#L27), so space-separated "w s e n" is what I'm looking for.

This also removes the trailing slash from `/dev/stdin`, which was giving me
`Error: ENOTDIR: not a directory, stat '/dev/stdin/'`