### PR TITLE
Removed trailing `/` that was causing a Node.js error when using `std…

### DIFF
--- a/bin/geojson-extent
+++ b/bin/geojson-extent
@@ -3,7 +3,7 @@
 var geojsonExtent = require('../'),
     rw = require('rw');
 
-var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin/')));
+var ext = geojsonExtent(JSON.parse(rw.readFileSync('/dev/stdin')));
 
 if (process.argv[2] == 'leaflet') {
     console.log(JSON.stringify([


### PR DESCRIPTION
Removed trailing `/` that was causing a Node.js error when using `stdin` as input.

Using:

`$ geojson-extent < file.geojson`

A node.js error is thrown because of the trailing backslash:

```
fs.js:114
    throw err;
    ^

Error: ENOTDIR: not a directory, stat '/dev/stdin/'
    at Object.statSync (fs.js:855:3)
    at Object.module.exports [as readFileSync] (/usr/lib/node_modules/@mapbox/geojson-extent/node_modules/rw/lib/rw/read-file-sync.js:5:10)
    at Object.<anonymous> (/usr/lib/node_modules/@mapbox/geojson-extent/bin/geojson-extent:6:39)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
```