### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# global owners
+
+*        @mapbox/maps-api


### PR DESCRIPTION
Per request from @guptabless, adding a `CODEOWNERS` for this repo and assigning ownership to @mapbox/maps-api.